### PR TITLE
Separate apply ay

### DIFF
--- a/foyer/atomtyper.py
+++ b/foyer/atomtyper.py
@@ -18,6 +18,7 @@ def find_atomtypes(topology, forcefield, max_iter=10):
 
     """
     typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 'atomtype': None} for atom in topology.atoms()}
+
     rules = _load_rules(forcefield, typemap)
 
     # Only consider rules for elements found in topology

--- a/foyer/forcefield.py
+++ b/foyer/forcefield.py
@@ -213,6 +213,7 @@ def _update_atomtypes(unatomtyped_topology, res_name, prototype):
             for old_atom, new_atom_id in zip([atom for atom in res.atoms()], [atom.id for atom in prototype.atoms()]):
                 old_atom.id = new_atom_id
 
+
 def _separate_urey_bradleys(system, topology):
     """ Separate urey bradley bonds from harmonic bonds in OpenMM System
 
@@ -243,9 +244,10 @@ def _separate_urey_bradleys(system, topology):
     system.addForce(harmonic_bond_force)
     system.addForce(ub_force)
 
+
 def _error_or_warn(error, msg):
     """Raise an error or warning if topology objects are not fully parameterized.
-    
+
     Parameters
     ----------
     error : bool
@@ -257,6 +259,78 @@ def _error_or_warn(error, msg):
         raise Exception(msg)
     else:
         warnings.warn(msg)
+
+
+def _check_bonds(data, structure, assert_bond_params):
+    """Check if any bonds lack paramters."""
+    if data.bonds:
+        missing = [b for b in structure.bonds
+                   if b.type is None]
+        if missing:
+            nmissing = len(structure.bonds) - len(missing)
+            msg = ("Parameters have not been assigned to all bonds. "
+                   "Total system bonds: {}, Parametrized bonds: {}"
+                   "".format(len(structure.bonds), nmissing))
+            _error_or_warn(assert_bond_params, msg)
+
+
+def _check_angles(data, structure, verbose, assert_angle_params):
+    """Check if all angles were found and parametrized."""
+    if data.angles and (len(data.angles) != len(structure.angles)):
+        msg = ("Parameters have not been assigned to all angles. Total "
+               "system angles: {}, Parameterized angles: {}"
+               "".format(len(data.angles), len(structure.angles)))
+        _error_or_warn(assert_angle_params, msg)
+
+    if verbose:
+        for omm_ids in data.angles:
+            missing_angle = True
+            for pmd_angle in structure.angles:
+                pmd_ids = (pmd_angle.atom1.idx, pmd_angle.atom2.idx, pmd_angle.atom3.idx)
+                if pmd_ids == omm_ids:
+                    missing_angle = False
+            if missing_angle:
+                print("Missing angle with ids {} and types {}.".format(
+                    omm_ids, [structure.atoms[idx].type for idx in omm_ids]))
+
+
+def _check_dihedrals(data, structure, verbose,
+                     assert_dihedral_params, assert_improper_params):
+    """Check if all dihedrals, including impropers, were found and parametrized."""
+    proper_dihedrals = [dihedral for dihedral in structure.dihedrals
+                        if not dihedral.improper]
+
+    if verbose:
+        for omm_ids in data.propers:
+            missing_dihedral = True
+            for pmd_proper in structure.rb_torsions:
+                pmd_ids = (pmd_proper.atom1.idx, pmd_proper.atom2.idx, pmd_proper.atom3.idx, pmd_proper.atom4.idx)
+                if pmd_ids == omm_ids:
+                    missing_dihedral = False
+            if missing_dihedral:
+                print('missing improper with ids {}'.format(pmd_ids))
+
+    if data.propers and len(data.propers) != \
+            len(proper_dihedrals) + len(structure.rb_torsions):
+        msg = ("Parameters have not been assigned to all proper dihedrals. "
+               "Total system dihedrals: {}, Parameterized dihedrals: {}. "
+               "Note that if your system contains torsions of Ryckaert-"
+               "Bellemans functional form, all of these torsions are "
+               "processed as propers.".format(len(data.propers),
+                                              len(proper_dihedrals) + len(structure.rb_torsions)))
+        _error_or_warn(assert_dihedral_params, msg)
+
+    improper_dihedrals = [dihedral for dihedral in structure.dihedrals
+                          if dihedral.improper]
+    if data.impropers and len(data.impropers) != \
+            len(improper_dihedrals) + len(structure.impropers):
+        msg = ("Parameters have not been assigned to all impropers. Total "
+               "system impropers: {}, Parameterized impropers: {}. "
+               "Note that if your system contains torsions of Ryckaert-"
+               "Bellemans functional form, all of these torsions are "
+               "processed as propers".format(len(data.impropers),
+                                             len(improper_dihedrals) + len(structure.impropers)))
+        _error_or_warn(assert_improper_params, msg)
 
 
 class Forcefield(app.ForceField):
@@ -420,99 +494,28 @@ class Forcefield(app.ForceField):
             raise FoyerError('Attempting to atom-type using a force field '
                     'with no atom type defitions.')
 
-        if not isinstance(topology, app.Topology):
-            residues = kwargs.get('residues')
-            topology, positions = generate_topology(topology,
-                    self.non_element_types, residues=residues)
-        else:
-            positions = np.empty(shape=(topology.getNumAtoms(), 3))
-            positions[:] = np.nan
-        box_vectors = topology.getPeriodicBoxVectors()
+        topology, positions = self._prepare_topology(topology, **kwargs)
+
         topology = self.run_atomtyping(topology, use_residue_map=use_residue_map)
-        # Extra args to make OMM 7.3 happy
-        # Option 1: Add to the kwargs dictionary
-        #kwargs['switchDistance'] = None
-        #system = self.createSystem(topology, *args, **kwargs)
-        # Option 2: Explicitly specify switchDistance 
-        #system = self.createSystem(topology, switchDistance=None, *args, **kwargs)
-        # Option 3: Default kwarg in createSystem
+
         system = self.createSystem(topology, *args, **kwargs)
+
         _separate_urey_bradleys(system, topology)
 
-        structure = pmd.openmm.load_topology(topology=topology, system=system)
-
-        '''
-        Check that all topology objects (angles, dihedrals, and impropers)
-        have parameters assigned. OpenMM will generate an error if bond parameters
-        are not assigned.
-        '''
         data = self._SystemData
 
-        if verbose:
-            for omm_ids in data.angles:
-                missing_angle = True
-                for pmd_angle in structure.angles:
-                    pmd_ids = (pmd_angle.atom1.idx, pmd_angle.atom2.idx, pmd_angle.atom3.idx)
-                    if pmd_ids == omm_ids:
-                        missing_angle = False
-                if missing_angle:
-                    print("Missing angle with ids {} and types {}.".format(
-                          omm_ids, [structure.atoms[idx].type for idx in omm_ids]))
-        if data.bonds:
-            missing = [b for b in structure.bonds
-                       if b.type is None]
-            if missing:
-                nmissing = len(structure.bonds) - len(missing)
-                msg = ("Parameters have not been assigned to all bonds. "
-                       "Total system bonds: {}, Parametrized bonds: {}"
-                       "".format(len(structure.bonds), nmissing))
-                _error_or_warn(assert_bond_params, msg)
-
-        if data.angles and (len(data.angles) != len(structure.angles)):
-            msg = ("Parameters have not been assigned to all angles. Total "
-                   "system angles: {}, Parameterized angles: {}"
-                   "".format(len(data.angles), len(structure.angles)))
-            _error_or_warn(assert_angle_params, msg)
-
-        proper_dihedrals = [dihedral for dihedral in structure.dihedrals
-                            if not dihedral.improper]
-
-        if verbose:
-            for omm_ids in data.propers:
-                missing_dihedral = True
-                for pmd_proper in structure.rb_torsions:
-                    pmd_ids = (pmd_proper.atom1.idx, pmd_proper.atom2.idx, pmd_proper.atom3.idx, pmd_proper.atom4.idx)
-                    if pmd_ids == omm_ids:
-                        missing_dihedral = False
-                if missing_dihedral:
-                    print('missing improper with ids {}'.format(pmd_ids))
-
-        if data.propers and len(data.propers) != \
-                len(proper_dihedrals) + len(structure.rb_torsions):
-            msg = ("Parameters have not been assigned to all proper dihedrals. "
-                   "Total system dihedrals: {}, Parameterized dihedrals: {}. "
-                   "Note that if your system contains torsions of Ryckaert-"
-                   "Bellemans functional form, all of these torsions are "
-                   "processed as propers.".format(len(data.propers),
-                   len(proper_dihedrals) + len(structure.rb_torsions)))
-            _error_or_warn(assert_dihedral_params, msg)
-
-        improper_dihedrals = [dihedral for dihedral in structure.dihedrals
-                              if dihedral.improper]
-        if data.impropers and len(data.impropers) != \
-                len(improper_dihedrals) + len(structure.impropers):
-            msg = ("Parameters have not been assigned to all impropers. Total "
-                   "system impropers: {}, Parameterized impropers: {}. "
-                   "Note that if your system contains torsions of Ryckaert-"
-                   "Bellemans functional form, all of these torsions are "
-                   "processed as propers".format(len(data.impropers),
-                   len(improper_dihedrals) + len(structure.impropers)))
-            _error_or_warn(assert_improper_params, msg)
-
+        structure = pmd.openmm.load_topology(topology=topology, system=system)
         structure.bonds.sort(key=lambda x: x.atom1.idx)
         structure.positions = positions
+        box_vectors = topology.getPeriodicBoxVectors()
         if box_vectors is not None:
             structure.box_vectors = box_vectors
+
+        _check_bonds(data, structure, assert_bond_params)
+        _check_angles(data, structure, verbose, assert_angle_params)
+        _check_dihedrals(data, structure, verbose,
+                              assert_dihedral_params, assert_improper_params)
+
         if references_file:
             atom_types = set(atom.type for atom in structure.atoms)
             self._write_references_to_file(atom_types, references_file)
@@ -806,6 +809,17 @@ class Forcefield(app.ForceField):
 
         return sys
 
+    def _prepare_topology(self, topology, **kwargs):
+        if not isinstance(topology, app.Topology):
+            residues = kwargs.get('residues')
+            topology, positions = generate_topology(topology,
+                                                    self.non_element_types, residues=residues)
+        else:
+            positions = np.empty(shape=(topology.getNumAtoms(), 3))
+            positions[:] = np.nan
+
+        return topology, positions
+
     def _write_references_to_file(self, atom_types, references_file):
         atomtype_references = {}
         for atype in atom_types:
@@ -828,5 +842,6 @@ class Forcefield(app.ForceField):
                         ', '.join(sorted(atomtypes)) + '}')
                 bibtex_ref = bibtex_ref[:-2] + note + bibtex_ref[-2:]
                 f.write('{}\n'.format(bibtex_ref))
+
 
 pmd.Structure.write_foyer = write_foyer

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -29,12 +29,14 @@ class SMARTSGraph(nx.Graph):
     node_dict_factory = OrderedDict
 
     def __init__(self, smarts_string, parser=None, name=None, overrides=None,
+                typemap=None,
                  *args, **kwargs):
         super(SMARTSGraph, self).__init__(*args, **kwargs)
 
         self.smarts_string = smarts_string
         self.name = name
         self.overrides = overrides
+        self.typemap = typemap
 
         if parser is None:
             self.ast = SMARTS().parse(smarts_string)
@@ -98,16 +100,16 @@ class SMARTSGraph(nx.Graph):
             return (self._atom_expr_matches(atom_expr.children[0], atom) or
                     self._atom_expr_matches(atom_expr.children[1], atom))
         elif atom_expr.data == 'atom_id':
-            return self._atom_id_matches(atom_expr.children[0], atom)
+            return self._atom_id_matches(atom_expr.children[0], atom, self.typemap)
         elif atom_expr.data == 'atom_symbol':
-            return self._atom_id_matches(atom_expr, atom)
+            return self._atom_id_matches(atom_expr, atom, self.typemap)
         else:
             raise TypeError('Expected atom_id, atom_symbol, and_expression, '
                             'or_expression, or not_expression. '
                             'Got {}'.format(atom_expr.data))
 
     @staticmethod
-    def _atom_id_matches(atom_id, atom):
+    def _atom_id_matches(atom_id, atom, typemap):
         atomic_num = atom.element.atomic_number
         if atom_id.data == 'atomic_num':
             return atomic_num == int(atom_id.children[0])
@@ -120,12 +122,14 @@ class SMARTSGraph(nx.Graph):
                 return atomic_num == pt.AtomicNum[str(atom_id.children[0])]
         elif atom_id.data == 'has_label':
             label = atom_id.children[0][1:]  # Strip the % sign from the beginning.
-            return label in atom.whitelist
+            return label in typemap[atom.index]['whitelist']
+            #return label in atom.whitelist
         elif atom_id.data == 'neighbor_count':
             return len(atom.bond_partners) == int(atom_id.children[0])
         elif atom_id.data == 'ring_size':
             cycle_len = int(atom_id.children[0])
-            for cycle in atom.cycles:
+            #for cycle in atom.cycles:
+            for cycle in typemap[atom.index]['cycles']:
                 if len(cycle) == cycle_len:
                     return True
             return False
@@ -137,7 +141,7 @@ class SMARTSGraph(nx.Graph):
         elif atom_id.data == 'matches_string':
             raise NotImplementedError('matches_string is not yet implemented')
 
-    def find_matches(self, topology):
+    def find_matches(self, topology, typemap):
         """Return sets of atoms that match this SMARTS pattern in a topology.
 
         Notes:
@@ -155,7 +159,7 @@ class SMARTSGraph(nx.Graph):
         ring_tokens = ['ring_size', 'ring_count']
         has_ring_rules = any(list(self.ast.find_data(token))
                              for token in ring_tokens)
-        _prepare_atoms(topology, compute_cycles=has_ring_rules)
+        _prepare_atoms(topology, typemap, compute_cycles=has_ring_rules)
 
         top_graph = nx.Graph()
         top_graph.add_nodes_from(((a.index, {'atom': a})
@@ -178,7 +182,8 @@ class SMARTSGraph(nx.Graph):
                 element = None
             self._graph_matcher = SMARTSMatcher(top_graph, self,
                                                 node_match=self._node_match,
-                                                element=element)
+                                                element=element,
+                                                typemap=typemap)
 
         matched_atoms = set()
         for mapping in self._graph_matcher.subgraph_isomorphisms_iter():
@@ -194,7 +199,7 @@ class SMARTSGraph(nx.Graph):
 
 
 class SMARTSMatcher(isomorphism.vf2userfunc.GraphMatcher):
-    def __init__(self, G1, G2, node_match, element):
+    def __init__(self, G1, G2, node_match, element, typemap):
         super(SMARTSMatcher, self).__init__(G1, G2, node_match)
         self.element = element
         if element not in [None, '*']:
@@ -291,20 +296,25 @@ def _find_chordless_cycles(bond_graph, max_cycle_size):
     return cycles
 
 
-def _prepare_atoms(topology, compute_cycles=False):
+def _prepare_atoms(topology, typemap, compute_cycles=False):
     """Compute cycles and add white-/blacklists to atoms."""
     atom1 = next(topology.atoms())
-    has_whitelists = hasattr(atom1, 'whitelist')
-    has_cycles = hasattr(atom1, 'cycles')
+    #has_whitelists = hasattr(atom1, 'whitelist')
+    #has_cycles = hasattr(atom1, 'cycles')
+    has_whitelists = 'whitelist' in typemap[atom1.index]
+    has_cycles = 'cycles' in typemap[atom1.index]
     compute_cycles = compute_cycles and not has_cycles
 
     if compute_cycles or not has_whitelists:
         for atom in topology.atoms():
             if compute_cycles:
-                atom.cycles = set()
+                #atom.cycles = set()
+                typemap[atom.index]['cycles'] = set()
             if not has_whitelists:
-                atom.whitelist = set()
-                atom.blacklist = set()
+                #atom.whitelist = set()
+                #atom.blacklist = set()
+                typemap[atom.index]['whitelist'] = set()
+                typemap[atom.index]['blacklist'] = set()
 
     if compute_cycles:
         bond_graph = nx.Graph()
@@ -313,4 +323,5 @@ def _prepare_atoms(topology, compute_cycles=False):
         all_cycles = _find_chordless_cycles(bond_graph, max_cycle_size=8)
         for atom, cycles in zip(bond_graph.nodes, all_cycles):
             for cycle in cycles:
-                atom.cycles.add(tuple(cycle))
+                #atom.cycles.add(tuple(cycle))
+                typemap[atom.index]['cycles'].add(tuple(cycle))

--- a/foyer/smarts_graph.py
+++ b/foyer/smarts_graph.py
@@ -134,7 +134,8 @@ class SMARTSGraph(nx.Graph):
                     return True
             return False
         elif atom_id.data == 'ring_count':
-            n_cycles = len(atom.cycles)
+            #n_cycles = len(atom.cycles)
+            n_cycles = len(typemap[atom.index]['cycles'])
             if n_cycles == int(atom_id.children[0]):
                 return True
             return False

--- a/foyer/tests/test_graph.py
+++ b/foyer/tests/test_graph.py
@@ -27,23 +27,34 @@ def test_init():
 def test_lazy_cycle_finding():
     mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
     top, _ = generate_topology(mol2)
+    typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 
+                            'atomtype': None}     
+                            for atom in top.atoms()}
 
-    rule = SMARTSGraph(smarts_string='[C]')
-    list(rule.find_matches(top))
-    assert not any([hasattr(a, 'cycles') for a in top.atoms()])
+    rule = SMARTSGraph(smarts_string='[C]', typemap=typemap)
+    list(rule.find_matches(top, typemap))
+    #assert not any([hasattr(a, 'cycles') for a in top.atoms()])
+    assert not any(['cycles' in typemap[a.index] for a in top.atoms()])
 
     ring_tokens = ['R1', 'r6']
     for token in ring_tokens:
-        rule = SMARTSGraph(smarts_string='[C;{}]'.format(token))
-        list(rule.find_matches(top))
-        assert all([hasattr(a, 'cycles') for a in top.atoms()])
+        rule = SMARTSGraph(smarts_string='[C;{}]'.format(token),
+                            typemap=typemap)
+        list(rule.find_matches(top, typemap))
+        #assert all([hasattr(a, 'cycles') for a in top.atoms()])
+        assert all(['cycles' in typemap[a.index] for a in top.atoms()])
 
 
 def test_cycle_finding_multiple():
     fullerene = pmd.load_file(get_fn('fullerene.pdb'), structure=True)
     top, _ = generate_topology(fullerene)
+    typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 
+                            'atomtype': None}     
+                            for atom in top.atoms()}
 
-    _prepare_atoms(top, compute_cycles=True)
-    cycle_lengths = [list(map(len, atom.cycles)) for atom in top.atoms()]
+    _prepare_atoms(top, typemap, compute_cycles=True)
+    #cycle_lengths = [list(map(len, atom.cycles)) for atom in top.atoms()]
+    cycle_lengths = [list(map(len, typemap[atom.index]['cycles'])) 
+                        for atom in top.atoms()]
     expected = [5, 6, 6]
     assert all(sorted(lengths) == expected for lengths in cycle_lengths)

--- a/foyer/tests/test_smarts.py
+++ b/foyer/tests/test_smarts.py
@@ -21,7 +21,7 @@ def _rule_match(top, typemap, smart, result):
 def _rule_match_count(top, typemap, smart, count):
     rule = SMARTSGraph(name='test', parser=PARSER, smarts_string=smart, 
             typemap=typemap)
-    assert len(list(rule.find_matches(top))) is count
+    assert len(list(rule.find_matches(top, typemap))) is count
 
 
 def test_ast():

--- a/foyer/tests/test_smarts.py
+++ b/foyer/tests/test_smarts.py
@@ -12,13 +12,15 @@ from foyer.tests.utils import get_fn
 PARSER = SMARTS()
 
 
-def _rule_match(top, smart, result):
-    rule = SMARTSGraph(name='test', parser=PARSER, smarts_string=smart)
-    assert bool(list(rule.find_matches(top))) is result
+def _rule_match(top, typemap, smart, result):
+    rule = SMARTSGraph(name='test', parser=PARSER, smarts_string=smart, 
+                    typemap=typemap)
+    assert bool(list(rule.find_matches(top, typemap))) is result
 
 
-def _rule_match_count(top, smart, count):
-    rule = SMARTSGraph(name='test', parser=PARSER, smarts_string=smart)
+def _rule_match_count(top, typemap, smart, count):
+    rule = SMARTSGraph(name='test', parser=PARSER, smarts_string=smart, 
+            typemap=typemap)
     assert len(list(rule.find_matches(top))) is count
 
 
@@ -40,29 +42,46 @@ def test_parse():
 def test_uniqueness():
     mol2 = pmd.load_file(get_fn('uniqueness_test.mol2'), structure=True)
     top, _ = generate_topology(mol2)
+    typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 
+                            'atomtype': None}     
+                            for atom in top.atoms()}
 
-    _rule_match(top, '[#6]1[#6][#6][#6][#6][#6]1', False)
-    _rule_match(top, '[#6]1[#6][#6][#6][#6]1', False)
-    _rule_match(top, '[#6]1[#6][#6][#6]1', True)
+
+    _rule_match(top, typemap, '[#6]1[#6][#6][#6][#6][#6]1', False)
+    _rule_match(top, typemap, '[#6]1[#6][#6][#6][#6]1', False)
+    _rule_match(top, typemap, '[#6]1[#6][#6][#6]1', True)
 
 
 def test_ringness():
     ring = pmd.load_file(get_fn('ring.mol2'), structure=True)
     top, _ = generate_topology(ring)
-    _rule_match(top, '[#6]1[#6][#6][#6][#6][#6]1', True)
+    typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 
+                            'atomtype': None}     
+                            for atom in top.atoms()}
+
+    _rule_match(top, typemap, '[#6]1[#6][#6][#6][#6][#6]1', True)
 
     not_ring = pmd.load_file(get_fn('not_ring.mol2'), structure=True)
     top, _ = generate_topology(not_ring)
-    _rule_match(top, '[#6]1[#6][#6][#6][#6][#6]1', False)
+    typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 
+                            'atomtype': None}     
+                            for atom in top.atoms()}
+
+    _rule_match(top, typemap, '[#6]1[#6][#6][#6][#6][#6]1', False)
 
 
 def test_fused_ring():
     fused = pmd.load_file(get_fn('fused.mol2'), structure=True)
     top, _ = generate_topology(fused)
-    rule = SMARTSGraph(name='test', parser=PARSER,
-                       smarts_string='[#6]12[#6][#6][#6][#6][#6]1[#6][#6][#6][#6]2')
+    typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 
+                            'atomtype': None}     
+                            for atom in top.atoms()}
 
-    match_indices = list(rule.find_matches(top))
+    rule = SMARTSGraph(name='test', parser=PARSER,
+                       smarts_string='[#6]12[#6][#6][#6][#6][#6]1[#6][#6][#6][#6]2',
+                       typemap=typemap)
+
+    match_indices = list(rule.find_matches(top, typemap))
     assert 3 in match_indices
     assert 4 in match_indices
     assert len(match_indices) == 2
@@ -72,17 +91,20 @@ def test_ring_count():
     # Two rings
     fused = pmd.load_file(get_fn('fused.mol2'), structure=True)
     top, _ = generate_topology(fused)
+    typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 
+                            'atomtype': None}     
+                            for atom in top.atoms()}
     rule = SMARTSGraph(name='test', parser=PARSER,
-                       smarts_string='[#6;R2]')
+                       smarts_string='[#6;R2]', typemap=typemap)
 
-    match_indices = list(rule.find_matches(top))
+    match_indices = list(rule.find_matches(top, typemap))
     for atom_idx in (3, 4):
         assert atom_idx in match_indices
     assert len(match_indices) == 2
 
     rule = SMARTSGraph(name='test', parser=PARSER,
-                       smarts_string='[#6;R1]')
-    match_indices = list(rule.find_matches(top))
+                       smarts_string='[#6;R1]', typemap=typemap)
+    match_indices = list(rule.find_matches(top, typemap))
     for atom_idx in (0, 1, 2, 5, 6, 7, 8, 9):
         assert atom_idx in match_indices
     assert len(match_indices) == 8
@@ -90,10 +112,14 @@ def test_ring_count():
     # One ring
     ring = pmd.load_file(get_fn('ring.mol2'), structure=True)
     top, _ = generate_topology(ring)
+    typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 
+                            'atomtype': None}     
+                            for atom in top.atoms()}
+
 
     rule = SMARTSGraph(name='test', parser=PARSER,
-                       smarts_string='[#6;R1]')
-    match_indices = list(rule.find_matches(top))
+                       smarts_string='[#6;R1]', typemap=typemap)
+    match_indices = list(rule.find_matches(top, typemap))
     for atom_idx in range(6):
         assert atom_idx in match_indices
     assert len(match_indices) == 6
@@ -120,6 +146,9 @@ def test_precedence_ast():
 def test_precedence():
     mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
     top, _ = generate_topology(mol2)
+    typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 
+                            'atomtype': None}     
+                            for atom in top.atoms()}
 
     checks = {'[C,O;C]': 2,
               '[C&O;C]': 0,
@@ -128,7 +157,7 @@ def test_precedence():
               }
 
     for smart, result in checks.items():
-        _rule_match_count(top, smart, result)
+        _rule_match_count(top, typemap, smart, result)
 
 
 def test_not_ast():
@@ -150,6 +179,9 @@ def test_not_ast():
 def test_not():
     mol2 = pmd.load_file(get_fn('ethane.mol2'), structure=True)
     top, _ = generate_topology(mol2)
+    typemap = {atom.index: {'whitelist': set(), 'blacklist': set(), 
+                            'atomtype': None}     
+                            for atom in top.atoms()}
 
     checks = {'[!O]': 8,
               '[!#5]': 8,
@@ -159,7 +191,7 @@ def test_not():
               '[!C;!H]': 0,
               }
     for smart, result in checks.items():
-        _rule_match_count(top, smart, result)
+        _rule_match_count(top, typemap, smart, result)
 
 
 def test_hexa_coordinated():


### PR DESCRIPTION
### PR Summary:
This was just a long chain of passing the `typemap`. In actuality, the first place we deal with the typemap if in `find_atomtypes: rules = _load_rules` because we make a `SMARTSGraph` object for each rule, and it's in the smartsgraph where we also specify whitelist, blacklist, cycles, etc. 

EDIT: so `SmartsMatcher` needs to know the typemap (this singular typemap that all rules will be operating on), and so we need to pass the typemap through `SmartsGraph`. At the end of the day, the vf2 node matching stuff needs to look at the typemap in `_node_match, _atom_id_matches, _atom_expr_matches`
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
